### PR TITLE
Try func to return err rather than panic

### DIFF
--- a/netrc/netrc.go
+++ b/netrc/netrc.go
@@ -219,6 +219,16 @@ func (m *Machine) UpdatePassword(newpass string) {
 	updateTokenValue(m.passtoken, newpass)
 }
 
+// TryUpdatePassword sets the password for the Machine m. Returns an error rather than panic
+func (m *Machine) TryUpdatePassword(newpass string) error {
+	m.Password = newpass
+	if m.passtoken == nil {
+		return fmt.Errorf(".netrc is corrupt - %s has a missing or invalid password token", m.Name)
+	}
+	updateTokenValue(m.passtoken, newpass)
+	return nil
+}
+
 // UpdateLogin sets the login for the Machine m.
 func (m *Machine) UpdateLogin(newlogin string) {
 	m.Login = newlogin

--- a/netrc/netrc_test.go
+++ b/netrc/netrc_test.go
@@ -605,3 +605,17 @@ func TestMissingPassword(t *testing.T) {
 	m.UpdateLogin("joeschmoe2")
 	m.UpdatePassword("TOKEN2")
 }
+
+func TestMissingPasswordErr(t *testing.T) {
+	b := "machine github.com\n  login joeschmoe\n  \n"
+	nrc, err := Parse(strings.NewReader(b))
+	if err != nil {
+		t.Fatal(err)
+	}
+	m := nrc.FindMachine("github.com")
+	m.UpdateLogin("joeschmoe2")
+	err = m.TryUpdatePassword("TOKEN2")
+	if err == nil {
+		t.Errorf("Expected a panic (.netrc is corrupt - github.com has a missing or invalid password token)")
+	}
+}


### PR DESCRIPTION
We should panic from trying to update the password, we should instead return an error and let the caller handle the error, but in order to not break the signature, added a new Function to return an error instead, caller will need to update to use new signature.